### PR TITLE
pycharmのre-format、inspection機能で自分なりに変更

### DIFF
--- a/Python/for3.py
+++ b/Python/for3.py
@@ -1,19 +1,30 @@
 # coding: UTF-8
-# 九九を求める
 
-def kuku(MaxValue):
-	max = MaxValue + 1
-	val = 0
-	for i in range(1, max):
-		for j in range(1, max):
-			val = i * j
-			print('%3d') % (val),
-		print('')
+from __future__ import unicode_literals, print_function, division, absolute_import
 
-print('九九を求める -日本式-')
-kuku(9)
 
-print('九九を求める -インド式-')
-kuku(20)
+def main():
+    # 九九を求める
 
+    def kuku(MaxValue):
+
+        i_max = MaxValue + 1
+        # val = 0
+        for i in range(1, i_max):
+            for j in range(1, i_max):
+                val = i * j
+                # print('%3d') % (val),
+                print("{0:3} ".format(val), end='')
+            print('')
+
+    print('九九を求める -日本式-')
+    kuku(9)
+
+    print('九九を求める -インド式-')
+    kuku(20)
+
+
+if __name__ == '__main__':
+    main()
+    exit(0)
 


### PR DESCRIPTION
・from __future__ import unicode_literals, print_function, division, absolute_importはpython2と3の互換用のおまじないです。
・rangeに対するメモリ効率の良いxrangeというのもあるようですが、python3では廃止されています。
・maxという関数があり、pycharmで怒られたので変数名をi_maxに変更しました。
・val=0は二重初期化でいらないようです。
・print構文の%表記はpython3で通りませんでした。